### PR TITLE
Assign hasCTF attribute in output generation

### DIFF
--- a/flexutils/protocols/protocol_annotate_space.py
+++ b/flexutils/protocols/protocol_annotate_space.py
@@ -36,6 +36,7 @@ from pyworkflow.protocol.params import PointerParam, IntParam, MultiPointerParam
 import pyworkflow.utils as pwutils
 from pyworkflow.utils.properties import Message
 from pyworkflow.gui.dialog import askYesNo
+from pyworkflow.object import Boolean
 
 from pwem.protocols import ProtAnalysis3D
 
@@ -131,6 +132,7 @@ class ProtFlexAnnotateSpace(ProtAnalysis3D, ProtFlexBase):
 
             newClass = Class()
             newClass.copyInfo(particles)
+            newClass._hasCTF = Boolean(particles.hasCTF())
             newClass.setAcquisition(particles.getAcquisition())
             representative = Rep(progName=progName)
             if hasattr(representative, "setSamplingRate"):

--- a/flexutils/protocols/protocol_annotate_space.py
+++ b/flexutils/protocols/protocol_annotate_space.py
@@ -132,7 +132,7 @@ class ProtFlexAnnotateSpace(ProtAnalysis3D, ProtFlexBase):
 
             newClass = Class()
             newClass.copyInfo(particles)
-            newClass._hasCTF = Boolean(particles.hasCTF())
+            newClass.setHasCTF(particles.hasCTF())
             newClass.setAcquisition(particles.getAcquisition())
             representative = Rep(progName=progName)
             if hasattr(representative, "setSamplingRate"):

--- a/flexutils/protocols/protocol_associate_flex_space_to_particles.py
+++ b/flexutils/protocols/protocol_associate_flex_space_to_particles.py
@@ -62,7 +62,7 @@ class ProtFlexAssociateSpace(ProtAnalysis3D, ProtFlexBase):
 
         outSet = self._createSetOfParticlesFlex()
         outSet.copyInfo(particlesFlex)
-        outSet._hasCTF = Boolean(particlesFlex.hasCTF())
+        outSet.setHasCTF(particlesFlex.hasCTF())
 
         for particleFlex, particle in zip(particlesFlex.iterItems(), particles.iterItems()):
             particleFlex.setLocation(particle.getLocation())

--- a/flexutils/protocols/protocol_associate_flex_space_to_particles.py
+++ b/flexutils/protocols/protocol_associate_flex_space_to_particles.py
@@ -25,27 +25,13 @@
 # **************************************************************************
 
 
-import os
-import numpy as np
-from sklearn.neighbors import KDTree
-from xmipp_metadata.image_handler import ImageHandler
-
 from pyworkflow import BETA
-from pyworkflow.protocol import LEVEL_ADVANCED
-from pyworkflow.protocol.params import PointerParam, IntParam, MultiPointerParam, EnumParam
-import pyworkflow.utils as pwutils
-from pyworkflow.utils.properties import Message
-from pyworkflow.gui.dialog import askYesNo
+from pyworkflow.protocol.params import PointerParam
+from pyworkflow.object import Boolean
 
 from pwem.protocols import ProtAnalysis3D
 
-import flexutils
-from flexutils.utils import getOutputSuffix, computeNormRows
 from flexutils.protocols import ProtFlexBase
-from flexutils.objects import SetOfVolumesFlex, VolumeFlex
-import flexutils.constants as const
-
-import xmipp3
 
 
 class ProtFlexAssociateSpace(ProtAnalysis3D, ProtFlexBase):
@@ -76,6 +62,7 @@ class ProtFlexAssociateSpace(ProtAnalysis3D, ProtFlexBase):
 
         outSet = self._createSetOfParticlesFlex()
         outSet.copyInfo(particlesFlex)
+        outSet._hasCTF = Boolean(particlesFlex.hasCTF())
 
         for particleFlex, particle in zip(particlesFlex.iterItems(), particles.iterItems()):
             particleFlex.setLocation(particle.getLocation())

--- a/flexutils/protocols/protocol_cluster_space.py
+++ b/flexutils/protocols/protocol_cluster_space.py
@@ -122,7 +122,7 @@ class ProtFlexClusterSpace(ProtAnalysis3D, ProtFlexBase):
 
             newClass = Class()
             newClass.copyInfo(particles)
-            newClass._hasCTF = Boolean(particles.hasCTF())
+            newClass.setHasCTF(particles.hasCTF())
             newClass.setAcquisition(particles.getAcquisition())
             representative = Rep(progName=progName)
 

--- a/flexutils/protocols/protocol_cluster_space.py
+++ b/flexutils/protocols/protocol_cluster_space.py
@@ -34,6 +34,7 @@ from pyworkflow.protocol.params import PointerParam, IntParam, MultiPointerParam
 import pyworkflow.utils as pwutils
 from pyworkflow.utils.properties import Message
 from pyworkflow.gui.dialog import askYesNo
+from pyworkflow.object import Boolean
 
 from pwem.protocols import ProtAnalysis3D
 
@@ -121,6 +122,7 @@ class ProtFlexClusterSpace(ProtAnalysis3D, ProtFlexBase):
 
             newClass = Class()
             newClass.copyInfo(particles)
+            newClass._hasCTF = Boolean(particles.hasCTF())
             newClass.setAcquisition(particles.getAcquisition())
             representative = Rep(progName=progName)
 

--- a/flexutils/protocols/protocol_dimred.py
+++ b/flexutils/protocols/protocol_dimred.py
@@ -29,7 +29,7 @@ import os
 import numpy as np
 
 from pyworkflow import BETA
-from pyworkflow.object import CsvList
+from pyworkflow.object import CsvList, Boolean
 from pyworkflow.protocol import LEVEL_ADVANCED
 from pyworkflow.protocol.params import PointerParam, EnumParam, IntParam, BooleanParam, FloatParam, StringParam, \
                                        GPU_LIST, USE_GPU
@@ -138,6 +138,7 @@ class ProtFlexDimRedSpace(ProtAnalysis3D, ProtFlexBase):
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
 
         partSet.copyInfo(inputSet)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         idx = 0

--- a/flexutils/protocols/protocol_dimred.py
+++ b/flexutils/protocols/protocol_dimred.py
@@ -138,7 +138,7 @@ class ProtFlexDimRedSpace(ProtAnalysis3D, ProtFlexBase):
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
 
         partSet.copyInfo(inputSet)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         idx = 0

--- a/flexutils/protocols/protocol_select_views.py
+++ b/flexutils/protocols/protocol_select_views.py
@@ -31,6 +31,7 @@ from xmipp_metadata.image_handler import ImageHandler
 from pyworkflow import BETA
 from pyworkflow.protocol.params import PointerParam, FloatParam, EnumParam
 import pyworkflow.utils as pwutils
+from pyworkflow.object import Boolean
 
 from pwem.viewers.showj import *
 from pwem.protocols import ProtAnalysis3D
@@ -104,6 +105,7 @@ class ProtFlexSelectViews(ProtAnalysis3D):
         suffix = getOutputSuffix(self, SetOfParticles)
         output_particles = self._createSetOfParticles(suffix)
         output_particles.copyInfo(particles)
+        output_particles._hasCTF = Boolean(particles.hasCTF())
 
         # Loop particles and determine if the lie within the polygon delimited areas
         points_file = self._getExtraPath("point.txt")

--- a/flexutils/protocols/protocol_select_views.py
+++ b/flexutils/protocols/protocol_select_views.py
@@ -105,7 +105,7 @@ class ProtFlexSelectViews(ProtAnalysis3D):
         suffix = getOutputSuffix(self, SetOfParticles)
         output_particles = self._createSetOfParticles(suffix)
         output_particles.copyInfo(particles)
-        output_particles._hasCTF = Boolean(particles.hasCTF())
+        output_particles.setHasCTF(particles.hasCTF())
 
         # Loop particles and determine if the lie within the polygon delimited areas
         points_file = self._getExtraPath("point.txt")

--- a/flexutils/protocols/xmipp/protocol_angular_align_deep_nma.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_deep_nma.py
@@ -293,6 +293,7 @@ class TensorflowProtAngularAlignmentDeepNMA(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.NMA)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_angular_align_deep_nma.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_deep_nma.py
@@ -293,9 +293,9 @@ class TensorflowProtAngularAlignmentDeepNMA(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.NMA)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         correctionFactor = Xdim / self.newXdim

--- a/flexutils/protocols/xmipp/protocol_angular_align_deep_pose.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_deep_pose.py
@@ -331,9 +331,9 @@ class TensorflowProtAngularAlignmentDeepPose(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         correctionFactor = Xdim / self.newXdim

--- a/flexutils/protocols/xmipp/protocol_angular_align_deep_pose.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_deep_pose.py
@@ -331,6 +331,7 @@ class TensorflowProtAngularAlignmentDeepPose(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
@@ -33,7 +33,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import String, Integer, CsvList
+from pyworkflow.object import String, Integer, CsvList, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -350,6 +350,7 @@ class TensorflowProtAngularAlignmentHetSiren(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.HETSIREN)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
@@ -350,9 +350,9 @@ class TensorflowProtAngularAlignmentHetSiren(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.HETSIREN)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         correctionFactor = Xdim / self.newXdim

--- a/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_het_siren.py
@@ -352,7 +352,7 @@ class TensorflowProtAngularAlignmentHetSiren(ProtAnalysis3D, ProtFlexBase):
         partSet = self._createSetOfParticlesFlex(progName=const.HETSIREN)
 
         partSet.copyInfo(inputSet)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         correctionFactor = Xdim / self.newXdim

--- a/flexutils/protocols/xmipp/protocol_angular_align_homo_siren.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_homo_siren.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import String, Integer
+from pyworkflow.object import String, Integer, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -336,6 +336,7 @@ class TensorflowProtAngularAlignmentHomoSiren(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_angular_align_homo_siren.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_homo_siren.py
@@ -336,9 +336,9 @@ class TensorflowProtAngularAlignmentHomoSiren(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         correctionFactor = Xdim / self.newXdim

--- a/flexutils/protocols/xmipp/protocol_angular_align_zernike3deep.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_zernike3deep.py
@@ -339,9 +339,9 @@ class TensorflowProtAngularAlignmentZernike3Deep(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.getFlexInfo().setProgName(const.ZERNIKE3D)
         partSet.setAlignmentProj()
 

--- a/flexutils/protocols/xmipp/protocol_angular_align_zernike3deep.py
+++ b/flexutils/protocols/xmipp/protocol_angular_align_zernike3deep.py
@@ -339,6 +339,7 @@ class TensorflowProtAngularAlignmentZernike3Deep(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.getFlexInfo().setProgName(const.ZERNIKE3D)

--- a/flexutils/protocols/xmipp/protocol_angular_alignment_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_angular_alignment_zernike3d.py
@@ -33,7 +33,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float, String
+from pyworkflow.object import Integer, Float, String, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -258,6 +258,7 @@ class XmippProtAngularAlignmentZernike3D(ProtAnalysis3D, ProtFlexBase):
         angles = mdOut[:, ["angleRot", "angleTilt", "anglePsi"]]
 
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
+        partSet._hasCTF = Boolean(inputParticles.hasCTF())
         inputMask = inputParticles.getFlexInfo().refMask.get() if isinstance(inputParticles, SetOfParticlesFlex) else self.inputVolumeMask.get().getFileName()
         inputVolume = inputParticles.getFlexInfo().refMap.get() if isinstance(inputParticles, SetOfParticlesFlex) else self.inputVolume.get().getFileName()
 

--- a/flexutils/protocols/xmipp/protocol_angular_alignment_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_angular_alignment_zernike3d.py
@@ -258,11 +258,11 @@ class XmippProtAngularAlignmentZernike3D(ProtAnalysis3D, ProtFlexBase):
         angles = mdOut[:, ["angleRot", "angleTilt", "anglePsi"]]
 
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
-        partSet._hasCTF = Boolean(inputParticles.hasCTF())
         inputMask = inputParticles.getFlexInfo().refMask.get() if isinstance(inputParticles, SetOfParticlesFlex) else self.inputVolumeMask.get().getFileName()
         inputVolume = inputParticles.getFlexInfo().refMap.get() if isinstance(inputParticles, SetOfParticlesFlex) else self.inputVolume.get().getFileName()
 
         partSet.copyInfo(inputParticles)
+        partSet.setHasCTF(inputParticles.hasCTF())
         partSet.setAlignmentProj()
 
         inverseTransform = partSet.getAlignment() == ALIGN_PROJ

--- a/flexutils/protocols/xmipp/protocol_assign_heterogeneity_priors_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_assign_heterogeneity_priors_zernike3d.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float, String
+from pyworkflow.object import Integer, Float, String, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -254,6 +254,7 @@ class XmippProtHeterogeneityPriorsZernike3D(ProtAnalysis3D, ProtFlexBase):
         angles = mdOut[:, ["angleRot", "angleTilt", "anglePsi"]]
 
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
+        partSet._hasCTF = Boolean(inputParticles.hasCTF())
 
         partSet.copyInfo(inputParticles)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_assign_heterogeneity_priors_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_assign_heterogeneity_priors_zernike3d.py
@@ -254,9 +254,9 @@ class XmippProtHeterogeneityPriorsZernike3D(ProtAnalysis3D, ProtFlexBase):
         angles = mdOut[:, ["angleRot", "angleTilt", "anglePsi"]]
 
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
-        partSet._hasCTF = Boolean(inputParticles.hasCTF())
 
         partSet.copyInfo(inputParticles)
+        partSet.setHasCTF(inputParticles.hasCTF())
         partSet.setAlignmentProj()
 
         inverseTransform = partSet.getAlignment() == ALIGN_PROJ

--- a/flexutils/protocols/xmipp/protocol_cluster_structures_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_cluster_structures_zernike3d.py
@@ -29,6 +29,7 @@ import os
 import numpy as np
 
 from pyworkflow import BETA
+from pyworkflow.object import Boolean
 from pyworkflow.protocol.params import PointerParam, FloatParam
 
 from pwem.protocols import ProtAnalysis3D
@@ -109,6 +110,7 @@ class XmippProtClusterStructuresZernike3D(ProtAnalysis3D, ProtFlexBase):
 
             newClass = ClassStructFlex(progName=const.ZERNIKE3D)
             newClass.copyInfo(particles)
+            newClass._hasCTF = Boolean(particles.hasCTF())
             representative = AtomStructFlex(progName=const.ZERNIKE3D)
             representative.setFileName(os.path.join(rep_path, "cluster_%d.pdb" % clInx))
 

--- a/flexutils/protocols/xmipp/protocol_cluster_structures_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_cluster_structures_zernike3d.py
@@ -110,7 +110,7 @@ class XmippProtClusterStructuresZernike3D(ProtAnalysis3D, ProtFlexBase):
 
             newClass = ClassStructFlex(progName=const.ZERNIKE3D)
             newClass.copyInfo(particles)
-            newClass._hasCTF = Boolean(particles.hasCTF())
+            newClass.setHasCTF(particles.hasCTF())
             representative = AtomStructFlex(progName=const.ZERNIKE3D)
             representative.setFileName(os.path.join(rep_path, "cluster_%d.pdb" % clInx))
 

--- a/flexutils/protocols/xmipp/protocol_focus_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_focus_zernike3d.py
@@ -31,7 +31,7 @@ import os
 from xmipp_metadata.metadata import XmippMetaData
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float
+from pyworkflow.object import Integer, Float, Boolean
 from pyworkflow import VERSION_2_0
 
 from pwem.protocols import ProtAnalysis3D
@@ -120,6 +120,7 @@ class XmippProtFocusZernike3D(ProtAnalysis3D, ProtFlexBase):
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         coeffs = np.asarray([np.fromstring(item, sep=',') for item in mdOut[:, "sphCoefficients"]])
         deformation = mdOut[:, "sphDeformation"]

--- a/flexutils/protocols/xmipp/protocol_focus_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_focus_zernike3d.py
@@ -120,7 +120,7 @@ class XmippProtFocusZernike3D(ProtAnalysis3D, ProtFlexBase):
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         coeffs = np.asarray([np.fromstring(item, sep=',') for item in mdOut[:, "sphCoefficients"]])
         deformation = mdOut[:, "sphDeformation"]

--- a/flexutils/protocols/xmipp/protocol_interactive_flex_consensus.py
+++ b/flexutils/protocols/xmipp/protocol_interactive_flex_consensus.py
@@ -115,9 +115,9 @@ class TensorflowProtInteractiveFlexConsensus(ProtAnalysis3D, ProtFlexBase):
 
         suffix = getOutputSuffix(self, SetOfParticlesFlex)
         partSet = self._createSetOfParticlesFlex(suffix, progName=inputSet.getFlexInfo().getProgName())
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         idx = 0

--- a/flexutils/protocols/xmipp/protocol_interactive_flex_consensus.py
+++ b/flexutils/protocols/xmipp/protocol_interactive_flex_consensus.py
@@ -29,6 +29,7 @@ import numpy as np
 import os
 
 import pyworkflow.protocol.params as params
+from pyworkflow.object import Boolean
 from pyworkflow.utils.path import makePath
 from pyworkflow import VERSION_2_0
 
@@ -114,6 +115,7 @@ class TensorflowProtInteractiveFlexConsensus(ProtAnalysis3D, ProtFlexBase):
 
         suffix = getOutputSuffix(self, SetOfParticlesFlex)
         partSet = self._createSetOfParticlesFlex(suffix, progName=inputSet.getFlexInfo().getProgName())
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_deep_nma.py
+++ b/flexutils/protocols/xmipp/protocol_predict_deep_nma.py
@@ -184,7 +184,7 @@ class TensorflowProtPredictDeepNMA(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.NMA)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_deep_nma.py
+++ b/flexutils/protocols/xmipp/protocol_predict_deep_nma.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 import prody as pd
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float, String, CsvList
+from pyworkflow.object import Integer, Float, String, CsvList, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -184,6 +184,7 @@ class TensorflowProtPredictDeepNMA(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.NMA)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_deep_pose.py
+++ b/flexutils/protocols/xmipp/protocol_predict_deep_pose.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float, String, CsvList
+from pyworkflow.object import Integer, Float, String, CsvList, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -190,6 +190,7 @@ class TensorflowProtPredictDeepPose(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_deep_pose.py
+++ b/flexutils/protocols/xmipp/protocol_predict_deep_pose.py
@@ -190,7 +190,7 @@ class TensorflowProtPredictDeepPose(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_het_siren.py
+++ b/flexutils/protocols/xmipp/protocol_predict_het_siren.py
@@ -33,7 +33,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import String, Integer
+from pyworkflow.object import String, Integer, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -202,6 +202,7 @@ class TensorflowProtPredictHetSiren(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.HETSIREN)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_het_siren.py
+++ b/flexutils/protocols/xmipp/protocol_predict_het_siren.py
@@ -202,7 +202,7 @@ class TensorflowProtPredictHetSiren(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.HETSIREN)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_homo_siren.py
+++ b/flexutils/protocols/xmipp/protocol_predict_homo_siren.py
@@ -192,7 +192,7 @@ class TensorflowProtPredictHomoSiren(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_homo_siren.py
+++ b/flexutils/protocols/xmipp/protocol_predict_homo_siren.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import String
+from pyworkflow.object import String, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -192,6 +192,7 @@ class TensorflowProtPredictHomoSiren(ProtAnalysis3D):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticles()
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.setAlignmentProj()

--- a/flexutils/protocols/xmipp/protocol_predict_zernike3deep.py
+++ b/flexutils/protocols/xmipp/protocol_predict_zernike3deep.py
@@ -234,7 +234,7 @@ class TensorflowProtPredictZernike3Deep(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
+        partSet.setHasCTF(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.getFlexInfo().setProgName(const.ZERNIKE3D)

--- a/flexutils/protocols/xmipp/protocol_predict_zernike3deep.py
+++ b/flexutils/protocols/xmipp/protocol_predict_zernike3deep.py
@@ -32,7 +32,7 @@ from xmipp_metadata.metadata import XmippMetaData
 from xmipp_metadata.image_handler import ImageHandler
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, Float, String, CsvList
+from pyworkflow.object import Integer, Float, String, CsvList, Boolean
 from pyworkflow.utils.path import moveFile
 from pyworkflow import VERSION_2_0
 
@@ -234,6 +234,7 @@ class TensorflowProtPredictZernike3Deep(ProtAnalysis3D, ProtFlexBase):
 
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
 
         partSet.copyInfo(inputSet)
         partSet.getFlexInfo().setProgName(const.ZERNIKE3D)

--- a/flexutils/protocols/xmipp/protocol_reassign_reference_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_reassign_reference_zernike3d.py
@@ -31,7 +31,7 @@ import os
 from xmipp_metadata.metadata import XmippMetaData
 
 import pyworkflow.protocol.params as params
-from pyworkflow.object import Integer, String, Float
+from pyworkflow.object import Integer, String, Float, Boolean
 from pyworkflow import VERSION_2_0
 
 from pwem.protocols import ProtAnalysis3D
@@ -126,6 +126,7 @@ class XmippProtReassignReferenceZernike3D(ProtAnalysis3D, ProtFlexBase):
     def createOutputStep(self):
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
+        partSet._hasCTF = Boolean(inputSet.hasCTF())
         mdOut = XmippMetaData(self._getExtraPath("inputParticles_reassigned.xmd"))
 
         partSet.copyInfo(inputSet)

--- a/flexutils/protocols/xmipp/protocol_reassign_reference_zernike3d.py
+++ b/flexutils/protocols/xmipp/protocol_reassign_reference_zernike3d.py
@@ -126,10 +126,10 @@ class XmippProtReassignReferenceZernike3D(ProtAnalysis3D, ProtFlexBase):
     def createOutputStep(self):
         inputSet = self.inputParticles.get()
         partSet = self._createSetOfParticlesFlex(progName=const.ZERNIKE3D)
-        partSet._hasCTF = Boolean(inputSet.hasCTF())
         mdOut = XmippMetaData(self._getExtraPath("inputParticles_reassigned.xmd"))
 
         partSet.copyInfo(inputSet)
+        partSet.setHasCTF(inputSet.hasCTF())
         partSet.setAlignmentProj()
 
         coeffs = np.asarray([np.fromstring(item, sep=',') for item in mdOut[:, "sphCoefficients"]])

--- a/flexutils/protocols/xmipp/protocol_reconstruct_zart.py
+++ b/flexutils/protocols/xmipp/protocol_reconstruct_zart.py
@@ -64,7 +64,7 @@ class XmippProtReconstructZART(ProtReconstruct3D):
     def _defineParams(self, form):
         form.addSection(label='Input')
 
-        form.addHidden(params.USE_GPU, params.BooleanParam, default=True,
+        form.addHidden(params.USE_GPU, params.BooleanParam, default=False,
                        label="Use GPU for execution",
                        help="This protocol has both CPU and GPU implementation.\
                        Select the one you want to use.")


### PR DESCRIPTION
All Flexutils protocols have been modified to properly set the _hasCTF attribute. This should make possible to do subsets and refine with CryoSPARC programs.